### PR TITLE
The completion handler need invoke even failed to animate

### DIFF
--- a/UIView+Genie.m
+++ b/UIView+Genie.m
@@ -178,6 +178,9 @@ static const int BCTrapezoidWinding[4][4] = {
 
 
         NSLog(@"Genie Effect ERROR: The distance between %@ edge of animated view and %@ edge of %@ rect is incorrect. Animation will not be performed!", edgeDescription(edge), edgeDescription(edge), reverse ? @"star" : @"destination");
+        if(completion) {
+            completion();
+        }
         return;
     } else if (sign*(aPoints.a.v[axis] + sign*totalSize - bEndPoints.a.v[axis]) > 0.0f) {
         NSLog(@"Genie Effect Warning: The %@ edge of animated view overlaps %@ edge of %@ rect. Glitches may occur.",edgeDescription((edge + 2) % 4), edgeDescription(edge), reverse ? @"start" : @"destination");


### PR DESCRIPTION
Invoke the completion block even failed to animate.
It'll be better if the completion block with a NSError as parameter.
